### PR TITLE
Speed up API loading times by persisting data into the MongoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Currently, API provides todays on-air schedule for various Slovenian radio stati
 
 ## List of supported radio stations:
 
-- Val 202 - [API](https://slovenian-radio-api.lukabratos.now.sh/val202)
+- Val 202 - [API](https://slovenian-radio-api.lukabratos.now.sh/api/val202)
 - Radio Prvi - [API](https://slovenian-radio-api.lukabratos.now.sh/api/ra1)
 - Radio Maribor - [API](https://slovenian-radio-api.lukabratos.now.sh/api/rmb)
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@ Currently, API provides todays on-air schedule for various Slovenian radio stati
 
 ## List of supported radio stations:
 
-- Val 202 - [API](https://slovenian-radio-api-git-master.lukabratos.now.sh/api/val202)
-- Radio Prvi - [API](https://slovenian-radio-api-git-master.lukabratos.now.sh/api/ra1)
-- Radio Maribor - [API](https://slovenian-radio-api-git-master.lukabratos.now.sh/api/rmb)
+- Val 202 - [API](https://slovenian-radio-api.lukabratos.now.sh/val202)
+- Radio Prvi - [API](https://slovenian-radio-api.lukabratos.now.sh/api/ra1)
+- Radio Maribor - [API](https://slovenian-radio-api.lukabratos.now.sh/api/rmb)
 
 ## Response
 
 ```
 [
-    ...
-    {"time":"11.30","title":"Novice"},
-    {"time":"11.38","title":"Obvestila"},
-    ...
+    {"_id":"5cacf19bfc844567891ab460","time":"11.30","title":"Novice"},
+    {"_id":"5cacf19bfc84450c1e1ab461","time":"11.38","title":"Obvestila"}
 ]
 ```
 

--- a/api/rmb.js
+++ b/api/rmb.js
@@ -2,6 +2,7 @@ const express = require("express");
 const helmet = require("helmet");
 const request = require("request");
 const cheerio = require("cheerio");
+const MongoClient = require("mongodb").MongoClient;
 
 const app = express();
 app.use(helmet());
@@ -73,22 +74,58 @@ function generateScheduleJSON(timeList, titleList) {
 
 app.get("/api/rmb", (req, res) => {
   res.set("Content-Type", "application/json");
+  const collectionName = "RadioMariborSchedule_" + createFormattedDateString();
+  const user = process.env.USER;
+  const pass = process.env.PASS;
+  const uri =
+    "mongodb+srv://" +
+    user +
+    ":" +
+    pass +
+    "@slovenian-radio-api-rxdpk.mongodb.net/slovenian-radio-api?retryWrites=true";
 
-  request("https://www.rtvslo.si/radiomaribor/spored", function(
-    error,
-    response,
-    body
-  ) {
-    if (error != null && response.statusCode != 200) {
-      console.error("error:", error);
-    }
+  const client = new MongoClient(uri, { useNewUrlParser: true });
+  client.connect(err => {
+    if (err) throw err;
+    client
+      .db("slovenian-radio-api")
+      .collection(collectionName)
+      .find({})
+      .toArray(function(err, result) {
+        if (err) throw err;
+        if (result.length !== 0) {
+          res.status(200).send(JSON.stringify(result));
+          client.db.close;
+        } else {
+          request("https://www.rtvslo.si/radiomaribor/spored", function(
+            error,
+            response,
+            body
+          ) {
+            if (error != null && response.statusCode != 200) {
+              console.error("error:", error);
+            }
 
-    const $ = loadRadioMariborSchedule(body);
-    var scheduleTimeList = parseScheduleTime($);
-    var scheduleTitleList = parseScheduleTitle($);
+            const $ = loadRadioMariborSchedule(body);
+            var scheduleTimeList = parseScheduleTime($);
+            var scheduleTitleList = parseScheduleTitle($);
 
-    const result = generateScheduleJSON(scheduleTimeList, scheduleTitleList);
-    res.status(200).send(JSON.stringify(result));
+            const scheduleJSON = generateScheduleJSON(
+              scheduleTimeList,
+              scheduleTitleList
+            );
+
+            client
+              .db("slovenian-radio-api")
+              .collection(collectionName)
+              .insertMany(scheduleJSON, function(err, result) {
+                if (err) throw err;
+                res.status(200).send(JSON.stringify(result));
+                client.db.close;
+              });
+          });
+        }
+      });
   });
 });
 

--- a/api/val202.js
+++ b/api/val202.js
@@ -2,9 +2,16 @@ const express = require("express");
 const helmet = require("helmet");
 const request = require("request");
 const cheerio = require("cheerio");
+const MongoClient = require("mongodb").MongoClient;
 
 const app = express();
 app.use(helmet());
+
+function appendZeroIfNeeded(input) {
+  if (input < 10) {
+    return "0" + input;
+  }
+}
 
 function parseScheduleTime($) {
   var scheduleTimeList = [];
@@ -46,6 +53,17 @@ function parseScheduleTitle($) {
   return scheduleTitleList;
 }
 
+function createFormattedDateString() {
+  const date = new Date();
+  return (
+    date.getFullYear() +
+    "-" +
+    appendZeroIfNeeded(date.getMonth() + 1) +
+    "-" +
+    appendZeroIfNeeded(date.getDate())
+  );
+}
+
 function generateScheduleJSON(timeList, titleList) {
   var result = [];
   for (i = 0; i < timeList.length; i++) {
@@ -57,18 +75,58 @@ function generateScheduleJSON(timeList, titleList) {
 
 app.get("/api/val202", (req, res) => {
   res.set("Content-Type", "application/json");
+  const collectionName = "RadioVal202Schedule_" + createFormattedDateString();
+  const user = process.env.USER;
+  const pass = process.env.PASS;
+  const uri =
+    "mongodb+srv://" +
+    user +
+    ":" +
+    pass +
+    "@slovenian-radio-api-rxdpk.mongodb.net/slovenian-radio-api?retryWrites=true";
 
-  request("https://val202.rtvslo.si/spored/", function(error, response, body) {
-    if (error != null && response.statusCode != 200) {
-      console.error("error:", error);
-    }
+  const client = new MongoClient(uri, { useNewUrlParser: true });
+  client.connect(err => {
+    if (err) throw err;
+    client
+      .db("slovenian-radio-api")
+      .collection(collectionName)
+      .find({})
+      .toArray(function(err, result) {
+        if (err) throw err;
+        if (result.length !== 0) {
+          res.status(200).send(JSON.stringify(result));
+          client.db.close;
+        } else {
+          request("https://val202.rtvslo.si/spored/", function(
+            error,
+            response,
+            body
+          ) {
+            if (error != null && response.statusCode != 200) {
+              console.error("error:", error);
+            }
 
-    const $ = cheerio.load(body);
-    var scheduleTimeList = parseScheduleTime($);
-    var scheduleTitleList = parseScheduleTitle($);
+            const $ = cheerio.load(body);
+            var scheduleTimeList = parseScheduleTime($);
+            var scheduleTitleList = parseScheduleTitle($);
 
-    const result = generateScheduleJSON(scheduleTimeList, scheduleTitleList);
-    res.status(200).send(JSON.stringify(result));
+            const scheduleJSON = generateScheduleJSON(
+              scheduleTimeList,
+              scheduleTitleList
+            );
+
+            client
+              .db("slovenian-radio-api")
+              .collection(collectionName)
+              .insertMany(scheduleJSON, function(err, result) {
+                if (err) throw err;
+                res.status(200).send(JSON.stringify(result));
+                client.db.close;
+              });
+          });
+        }
+      });
   });
 });
 

--- a/now.json
+++ b/now.json
@@ -7,5 +7,9 @@
     { "src": "/api/val202", "dest": "api/val202.js" },
     { "src": "/api/rmb", "dest": "api/rmb.js" },
     { "src": "/api/ra1", "dest": "api/ra1.js" }
-  ]
+  ],
+  "env": {
+    "USER": "@user",
+    "PASS": "@pass"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "express": "^4.16.4",
     "helmet": "^3.16.0",
     "cheerio": "^1.0.0-rc.2",
-    "request": "^2.88.0"
+    "request": "^2.88.0",
+    "mongodb": "^3.2.3"
   },
   "scripts": {
     "start": "node ."

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,6 +73,11 @@ boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
+bson@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
+  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -487,6 +492,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+memory-pager@^1.0.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/memory-pager/-/memory-pager-1.5.0.tgz#d8751655d22d384682741c972f2c3d6dfa3e66b5"
+  integrity sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==
+
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
@@ -518,6 +528,25 @@ mime-types@~2.1.18:
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mongodb-core@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.2.3.tgz#eb9bcb876f169f5843fd135f7f7686dbac0e9e34"
+  integrity sha512-UyI0rmvPPkjOJV8XGWa9VCTq7R4hBVipimhnAXeSXnuAPjuTqbyfA5Ec9RcYJ1Hhu+ISnc8bJ1KfGZd4ZkYARQ==
+  dependencies:
+    bson "^1.1.1"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.2.3.tgz#4610ee33d300caa74329c2dd03e137210723cd91"
+  integrity sha512-jw8UyPsq4QleZ9z+t/pIVy3L++51vKdaJ2Q/XXeYxk/3cnKioAH8H6f5tkkDivrQL4PUgUOHe9uZzkpRFH1XtQ==
+  dependencies:
+    mongodb-core "^3.2.3"
+    safe-buffer "^5.1.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -642,6 +671,19 @@ request@^2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+require_optional@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/require_optional/-/require_optional-1.0.1.tgz#4cf35a4247f64ca3df8c2ef208cc494b1ca8fc2e"
+  integrity sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==
+  dependencies:
+    resolve-from "^2.0.0"
+    semver "^5.1.0"
+
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+  integrity sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=
+
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -649,6 +691,18 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+saslprep@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.2.tgz#da5ab936e6ea0bbae911ffec77534be370c9f52d"
+  integrity sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==
+  dependencies:
+    sparse-bitfield "^3.0.3"
+
+semver@^5.1.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 send@0.16.2:
   version "0.16.2"
@@ -680,6 +734,13 @@ serve-static@1.13.2:
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+sparse-bitfield@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz#ff4ae6e68656056ba4b3e792ab3334d38273ca11"
+  integrity sha1-/0rm5oZWBWuks+eSqzM004JzyhE=
+  dependencies:
+    memory-pager "^1.0.2"
 
 sshpk@^1.7.0:
   version "1.16.1"


### PR DESCRIPTION
Previously, when the API endpoint was hit, the program would load the website's HTML, scrape specific information, transform it to JSON, and return it.

This PR will optimize the loading time from few seconds to few hundred _ms_.

If website's content changed, we will scrape needed information, and persist it into the database. For every next request, information will be loaded from the database.

For now, there's a lot of code duplication which will be addressed in some of the upcoming PR's.